### PR TITLE
ci: add PR checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,33 @@
+name: PR Checks
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  build-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.16'
+      - run: go build ./...
+      - run: go test ./...
+
+  build-webapp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '14'
+          cache: npm
+          cache-dependency-path: webapp/package-lock.json
+      - run: npm ci
+        working-directory: webapp
+      - run: npm run lint --if-present
+        working-directory: webapp
+      - run: npm run build --if-present
+        working-directory: webapp
+      - run: npm test --if-present
+        working-directory: webapp


### PR DESCRIPTION
Adds a `pull_request`-triggered CI workflow so Dependabot PRs (and others) are built and tested.

## What it does

- **build-server**: Sets up Go 1.16, runs `go build ./...` and `go test ./...` for the server component.
- **build-webapp**: Sets up Node 14, runs `npm ci`, `npm run lint`, `npm run build`, and `npm test` for the webapp component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)